### PR TITLE
Build shared and module versions of LesHouches

### DIFF
--- a/LesHouches/Makefile.am
+++ b/LesHouches/Makefile.am
@@ -8,7 +8,7 @@ INCLUDEFILES = $(DOCFILES) LesHouchesReader.fh \
                LesHouchesFileReader.fh \
                 LesHouchesEventHandler.fh
 
-pkglib_LTLIBRARIES = LesHouches.la MadGraphReader.la
+pkglib_LTLIBRARIES = libLesHouches.la LesHouches.la MadGraphReader.la
 
 # Version info should be updated if any interface or persistent I/O
 # function is changed
@@ -21,6 +21,11 @@ MadGraphReader_la_SOURCES = MadGraphReader.cc MadGraphReader.h \
 # function is changed
 LesHouches_la_LDFLAGS = $(AM_LDFLAGS) -module $(LIBTOOLVERSIONINFO)
 LesHouches_la_SOURCES = $(mySOURCES) $(INCLUDEFILES)
+
+# Version info should be updated if any interface or persistent I/O
+# function is changed
+libLesHouches_la_LDFLAGS = $(AM_LDFLAGS) -shared $(LIBTOOLVERSIONINFO)
+libLesHouches_la_SOURCES = $(mySOURCES) $(INCLUDEFILES)
 
 include $(top_srcdir)/Config/Makefile.aminclude
 


### PR DESCRIPTION
Darwin/OSX Mach-O format has strict distinction between shared and module
libraries. Module (MH_BUNDLE) on Darwin is stricly for dlopen()'ing and
you are not allowed to link to it. The interface between CMSSW and ThePEG
is not implemented according to ThePEG design. Because of that we need
to link to internal ThePEG library, which is only indented to be loaded
by ThePEG run-time on demand. This change allows us to link to LesHouches
on Darwin.
