### PR TITLE
Add std::isnan & std::isinf to Config/std.h

### DIFF
--- a/Config/std.h
+++ b/Config/std.h
@@ -106,6 +106,9 @@ using std::mem_fun;
 using std::sqrt;
 //using std::pow;
 using std::atan2;
+// For PersistentOStream.h
+using std::isinf;
+using std::isnan;
 
 /** Powers - standard or non-standard */
 template <class ExponentT>


### PR DESCRIPTION
Needed by `PersistentOStream.h` header:

```
PersistentOStream.h: In member function 'ThePEG::PersistentOStream& ThePEG::PersistentOStream::operator<<(double)':
PersistentOStream.h:222:17: error: 'isnan' was not declared in this scope

PersistentOStream.h: In member function 'ThePEG::PersistentOStream& ThePEG::PersistentOStream::operator<<(float)':
PersistentOStream.h:235:17: error: 'isnan' was not declared in this scope

PersistentOStream.h:235:29: error: 'isinf' was not declared in this scope
```

Failed `GeneratorInterface/ThePEGInterface` in `CMSSW_8_1_X_2016-08-25-1800` on
`fc24_ppc64le_gcc620`.

Signed-off-by: David Abdurachmanov davidlt@cern.ch
